### PR TITLE
Some modify

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,9 @@ sapper_tmpl = "0.1"
 sapper_session = "0.1"
 sapper_logger = "0.1"
 
-
+[patch.crates-io]
+sapper_query = { git = 'https://github.com/sappworks/sapper_query.git' }
+sapper_body = { git = 'https://github.com/sappworks/sapper_body.git' }
+sapper_tmpl = { git = 'https://github.com/sappworks/sapper_tmpl.git' }
+sapper_session = { git = 'https://github.com/sappworks/sapper_session.git' }
+sapper_logger = { git = 'https://github.com/sappworks/sapper_logger.git' }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,15 +14,15 @@ pub use sapper::PathParams;
 pub use sapper_query::QueryParams;
 pub use sapper_body::FormParams;
 pub use sapper_body::JsonParams;
-pub use sapper_session::SessionVal;
+pub use sapper_session::{ SessionVal, set_cookie };
 pub use sapper_tmpl::Context;
 pub use sapper_tmpl::render;
 
-pub fn init(req: &mut Request) -> Result<()> {
+pub fn init(req: &mut Request, cookie_key: &'static str) -> Result<()> {
     sapper_logger::init(req)?;
     sapper_query::parse(req)?;
     sapper_body::parse(req)?;
-    sapper_session::session_val(req, "_sapp_session")?;
+    sapper_session::session_val(req, cookie_key)?;
     
     Ok(())
 }


### PR DESCRIPTION
1. export `set_cookie` function
2. `fn init(req: &mut Request) -> Result<()>` to `fn init(req: &mut Request, cookie_key: &'static str) -> Result<()>`, Let the framework users specify their own cookie key
3. Frame scaffolding updates on the cargo may not be timely, try to specify to the github version